### PR TITLE
added require for securerandom

### DIFF
--- a/lib/oauth1/helper.rb
+++ b/lib/oauth1/helper.rb
@@ -3,7 +3,7 @@ require 'addressable/uri'
 require 'cgi'
 require 'base64'
 require 'openssl'
-
+require 'securerandom'
 module OAuth1
   class Helper
     attr_reader :url_params


### PR DESCRIPTION
added require for securerandom to fix 
.rvm/gems/ruby-1.9.3-p392/gems/oauth1-0.0.1/lib/oauth1/helper.rb:16:in `initialize': uninitialized constant OAuth1::Helper::SecureRandom (NameError)
